### PR TITLE
Add default 'public-read' ACLs 

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,12 +13,14 @@ const copyFile = (event) => {
     const destinationBucket = event.destinationBucket;
     const fileKey = event.fileKey;
     const destinationKey = event?.destinationKey || fileKey;
+    const defaultACL = 'public-read';
 
     // Copying the object from source bucket to destination bucket
     const copyParams = {
         CopySource: `${sourceBucket}/${fileKey}`,  // Source format: /bucket-name/key
         Bucket: destinationBucket,  // Destination bucket
         Key: destinationKey,  // The destination key (same or different as needed)
+        ACL: defaultACL,  // Configure ACL of newly copied object
     };
 
     // Execute the copy command


### PR DESCRIPTION
Without a defined ACL, the copied object will default to 'private' making the files publicly inaccessible. The use case for these files is for public viewing on user-uploaded content, and should retain the 'public-read' ACL of the previous object(s).

This PR adds that ACL as a default, but we could also add it as a field in the payload if desired. 